### PR TITLE
Add fast JSON number parser.

### DIFF
--- a/util/number/README.md
+++ b/util/number/README.md
@@ -1,0 +1,11 @@
+### Benchmarks
+
+```
+$ go test -benchtime=10s -bench=.
+BenchmarkNumber_Val1-4          1000000000          18.3 ns/op         0 B/op          0 allocs/op
+BenchmarkStdlibFloat_Val1-4     200000000           57.4 ns/op         3 B/op          1 allocs/op
+BenchmarkNumber_Val2-4          300000000           43.1 ns/op         0 B/op          0 allocs/op
+BenchmarkStdlibFloat_Val2-4     200000000           94.3 ns/op        16 B/op          1 allocs/op
+PASS
+ok      github.com/itsmontoya/jsoon    84.174s
+```

--- a/util/number/decode.go
+++ b/util/number/decode.go
@@ -1,0 +1,94 @@
+package parseFloat
+
+import "math"
+
+// DecodeNumber decodes a sequence of bytes representing a JSON Number into
+// float64. Ported from cJSON.
+//
+// For reference see http://json.org/number.gif
+func DecodeNumber(num []byte) (n float64) {
+	var (
+		sign         float64 = 1
+		scale        int
+		subscale     int
+		signsubscale int = 1
+	)
+
+	func() {
+		var i int
+
+		// has sign?
+		if num[i] == '-' {
+			sign = -1
+			i++
+			if i >= len(num) {
+				return
+			}
+		}
+		// is zero
+		if num[i] == '0' {
+			i++
+			if i >= len(num) {
+				return
+			}
+		}
+		// number?
+		if num[i] >= '1' && num[i] <= '9' {
+			for num[i] >= '0' && num[i] <= '9' {
+				n = n*10 + float64(num[i]-'0')
+				i++
+				if i >= len(num) {
+					return
+				}
+			}
+		}
+		// fractional part?
+		if num[i] == '.' && (num[i+1] >= '0' && num[i+1] <= '9') {
+			i++
+			if i >= len(num) {
+				return
+			}
+			for num[i] >= '0' && num[i] <= '9' {
+				n = n*10 + float64(num[i]-'0')
+				i++
+				if i >= len(num) {
+					return
+				}
+				scale--
+			}
+		}
+		// exponent?
+		if num[i] == 'e' || num[i] == 'E' {
+			i++
+			if i >= len(num) {
+				return
+			}
+			// with sign?
+			if num[i] == '+' {
+				i++
+				if i >= len(num) {
+					return
+				}
+			} else if num[i] == '-' {
+				signsubscale = -1
+				i++
+				if i >= len(num) {
+					return
+				}
+			}
+			// number?
+			for num[i] >= '0' && num[i] <= '9' {
+				subscale = subscale*10 + int(num[i]-'0')
+				i++
+				if i >= len(num) {
+					return
+				}
+			}
+		}
+	}()
+
+	// number = +/- number.fraction * 10^+/- exponent
+	n = sign * n * math.Pow10(scale+subscale*signsubscale)
+
+	return
+}

--- a/util/number/decode_test.go
+++ b/util/number/decode_test.go
@@ -1,0 +1,51 @@
+package parseFloat
+
+import (
+	"strconv"
+	"testing"
+)
+
+var val float64
+var testVal1 = []byte("123")
+var testVal2 = []byte("-3.14159265e+23")
+
+func TestBasic(t *testing.T) {
+	if DecodeNumber(testVal1) != 123 {
+		t.Fatal("testVal1 decoded incorrectly")
+	}
+	if DecodeNumber(testVal2) != -3.14159265e+23 {
+		t.Fatal("testVal2 decoded incorrectly")
+	}
+}
+
+func BenchmarkNumber_Val1(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		val = DecodeNumber(testVal1)
+	}
+}
+
+func BenchmarkStdlibFloat_Val1(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		val, _ = strconv.ParseFloat(string(testVal1), 64)
+	}
+}
+
+func BenchmarkNumber_Val2(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		val = DecodeNumber(testVal2)
+	}
+}
+
+func BenchmarkStdlibFloat_Val2(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		val, _ = strconv.ParseFloat(string(testVal2), 64)
+	}
+}


### PR DESCRIPTION
Go 1.7.3

```
$ go test -benchtime=10s -bench=.
BenchmarkNumber_Val1-4          1000000000          18.3 ns/op         0 B/op          0 allocs/op
BenchmarkStdlibFloat_Val1-4     200000000           57.4 ns/op         3 B/op          1 allocs/op
BenchmarkNumber_Val2-4          300000000           43.1 ns/op         0 B/op          0 allocs/op
BenchmarkStdlibFloat_Val2-4     200000000           94.3 ns/op        16 B/op          1 allocs/op
PASS
```